### PR TITLE
Updated parameters used in making requests for clarity

### DIFF
--- a/lib/util/RestConnection.js
+++ b/lib/util/RestConnection.js
@@ -91,10 +91,10 @@ module.exports = class RestConnection {
    * @param {Object} params - request parameters
    * @param {String} [method='GET'] - HTTP method (GET/POST/PUT/DELETE/etc)
    * @param {Object} customHeaders - optional: extra headers to merge into request
-   * @param {*} [advancedOptions={}]
+   * @param {*} [additionalOptions={}] - Additional query parameters used in specific endpoints
    * @returns {Promise} resolving with axios request response.
    */
-  _makeRequest(endpoint, params, method = 'GET', customHeaders, advancedOptions = {}) {
+  _makeRequest(endpoint, params, method = 'GET', customHeaders, additionalOptions={}) {
     const fullUrl = this.getBaseUrl() + endpoint;
 
     switch (method.toUpperCase()) {
@@ -102,48 +102,48 @@ module.exports = class RestConnection {
         return this.get(fullUrl, params, customHeaders);
 
       case 'POST':
-        return this.post(fullUrl, params, customHeaders, advancedOptions);
+        return this.post(fullUrl, params, additionalOptions, customHeaders);
 
       case 'PATCH':
-        return this.post(fullUrl, params, customHeaders, advancedOptions, 'PATCH');
+        return this.post(fullUrl, params, additionalOptions, customHeaders, 'PATCH');
       
       case 'DELETE':
-        return this.post(fullUrl, params, customHeaders, advancedOptions, 'DELETE');
+        return this.post(fullUrl, params, additionalOptions, customHeaders, 'DELETE');
 
       case 'PUT':
-        return this.post(fullUrl, params, customHeaders, advancedOptions, 'PUT');
+        return this.post(fullUrl, params, additionalOptions, customHeaders, 'PUT');
     }
   }
 
-  get(url, params, customHeaders = {}, mergeHeaders = true) {
+  get(url, queryParams, customHeaders = {}, mergeHeaders = true) {
     const options = {
       method: 'GET',
       headers: this._getHeaders(customHeaders, mergeHeaders),
       url: url
     };
 
-    if (params) {
-      options.url += '?' + qs.stringify(params);
+    if (queryParams) {
+      options.url += '?' + qs.stringify(queryParams);
     }
     // console.log("Making GET request: ", options);
 
     return axios(options);
   }
 
-  post(url, params, customHeaders = {}, advancedOptions = {}, requestMethod = 'POST', mergeHeaders = true) {
+  post(url, requestBody, queryParams, customHeaders = {}, requestMethod = 'POST', mergeHeaders = true) {
     const options = {
       method: requestMethod,
       headers: this._getHeaders(customHeaders, mergeHeaders),
-      data: params,
+      data: requestBody,
       url: url
     };
 
-    if (advancedOptions.queryParams) {
-      options.url += '?' + qs.stringify(advancedOptions.queryParams);
+    if(queryParams){
+      options.url += '?' + qs.stringify(queryParams);
     }
 
-    if (params) {
-      options.data = params;
+    if (requestBody) {
+      options.data = requestBody;
     }
     // console.log("Making POST request: ", options);
 


### PR DESCRIPTION
+ Renamed advancedOptions to additionalOptions as these are additional query parameters added to the request
+ Renamed in get() params to queryParams for clarity in the type of parameter
+ Renamed in post(); 1) params to requestBody for clarity in the type of parameter. 2) advancedOptions to queryParams to better understand and handle cases where a POST request would also have query parameters (Some PUT methods use this)
ex: http://10.27.72.72:8080/2020u1Library/api-docs/index.html#/Object%20Management/updateObject

The changes made don't affect the existing samples as there was no change in the structure of _makeRequest